### PR TITLE
remove location header to prevent redirect

### DIFF
--- a/src/OAuth2Server/Controller/AuthorizeController.php
+++ b/src/OAuth2Server/Controller/AuthorizeController.php
@@ -41,6 +41,12 @@ class AuthorizeController extends AbstractActionController
         }
 
         if (!$server->validateAuthorizeRequest($request, $response)) {
+            $headers = $response->getHeaders();
+            $location = $headers->get('location');
+            if ($location)
+            {
+                $headers->removeHeader($location);
+            }
             return new JsonModel($response->getContent());
         }
 


### PR DESCRIPTION
when this header is set, the error messages are lost due to the 302. The stops the redirect and dies on screen.
