### PR TITLE
bumping http-bridge dependency to tagged version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "homepage": "http://github.com/diablomedia/zf2-oauth2-server",
     "require": {
         "php": ">=5.3.0",
-        "diablomedia/oauth2-server-zendhttp-bridge": "dev-master"
+        "diablomedia/oauth2-server-zendhttp-bridge": "^1.0.0"
     },
     "autoload": {
         "psr-0": {"OAuth2Server": "src/"},


### PR DESCRIPTION
Tested that just depending on this version of this lib pulls down the 1.0.0 tag of the bridge.