### PR TITLE
Migrating to Laminas

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -2,18 +2,18 @@
 
 namespace OAuth2Server;
 
-use Zend\ModuleManager\Feature\AutoloaderProviderInterface;
-use Zend\Mvc\ModuleRouteListener;
-use Zend\Mvc\MvcEvent;
-use Zend\ServiceManager\ServiceManager;
-use OAuth2\ZendHttpPhpEnvironmentBridge\Response;
+use Laminas\ModuleManager\Feature\AutoloaderProviderInterface;
+use Laminas\Mvc\ModuleRouteListener;
+use Laminas\Mvc\MvcEvent;
+use Laminas\ServiceManager\ServiceManager;
+use OAuth2\LaminasHttpPhpEnvironmentBridge\Response;
 
 class Module implements AutoloaderProviderInterface
 {
     public function getAutoloaderConfig()
     {
         return [
-            'Zend\Loader\StandardAutoloader' => [
+            'Laminas\Loader\StandardAutoloader' => [
                 'namespaces' => [
                     // if we're in a namespace deeper than one level we need to fix the \ in the path
                     __NAMESPACE__ => __DIR__ . '/src/' . str_replace('\\', '/', __NAMESPACE__),

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=5.6.0",
         "bshaffer/oauth2-server-php": "^1.7",
-        "diablomedia/oauth2-server-zendhttp-bridge": "dev-laminas as 2.0.0",
+        "diablomedia/oauth2-server-zendhttp-bridge": "^3.0.0",
         "laminas/laminas-form": "^2.0.0",
         "laminas/laminas-view": "^2.0.0",
         "laminas/laminas-mvc": "^2.0 || ^3.0"

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,17 @@
 {
     "name": "diablomedia/zf2-oauth2-server",
     "description": "ZF2 implementation of oauth2-server-php",
-    "keywords": ["oauth", "oauth2", "auth", "zf2", "zendframework"],
+    "keywords": [
+        "oauth",
+        "oauth2",
+        "auth",
+        "zf2",
+        "zendframework",
+        "laminas"
+    ],
     "type": "library",
     "license": "MIT",
-    "authors":[
+    "authors": [
         {
             "name": "Ari Pringle",
             "email": "ari@diablomedia.com",
@@ -20,13 +27,15 @@
     "require": {
         "php": ">=5.6.0",
         "bshaffer/oauth2-server-php": "^1.7",
-        "diablomedia/oauth2-server-zendhttp-bridge": "^2.0.0",
-        "zendframework/zend-form": "^2.0.0",
-        "zendframework/zend-view": "^2.0.0",
-        "zendframework/zend-mvc": "^2.0 || ^3.0"
+        "diablomedia/oauth2-server-zendhttp-bridge": "dev-laminas as 2.0.0",
+        "laminas/laminas-form": "^2.0.0",
+        "laminas/laminas-view": "^2.0.0",
+        "laminas/laminas-mvc": "^2.0 || ^3.0"
     },
     "autoload": {
-        "psr-0": {"OAuth2Server": "src/"},
+        "psr-0": {
+            "OAuth2Server": "src/"
+        },
         "classmap": [
             "./Module.php"
         ]

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$request of static method OAuth2\\\\ZendHttpPhpEnvironmentBridge\\\\Request\\:\\:createFromRequest\\(\\) expects Zend\\\\Http\\\\PhpEnvironment\\\\Request, Zend\\\\Stdlib\\\\RequestInterface given\\.$#"
+			message: "#^Parameter \\#1 \\$request of static method OAuth2\\\\LaminasHttpPhpEnvironmentBridge\\\\Request\\:\\:createFromRequest\\(\\) expects Laminas\\\\Http\\\\PhpEnvironment\\\\Request, Laminas\\\\Stdlib\\\\RequestInterface given\\.$#"
 			count: 2
 			path: src/OAuth2Server/Controller/AuthorizeController.php
 
 		-
-			message: "#^Parameter \\#2 \\$response of method OAuth2\\\\Server\\:\\:handleAuthorizeRequest\\(\\) expects OAuth2\\\\ResponseInterface, Zend\\\\Stdlib\\\\ResponseInterface given\\.$#"
+			message: "#^Parameter \\#2 \\$response of method OAuth2\\\\Server\\:\\:handleAuthorizeRequest\\(\\) expects OAuth2\\\\ResponseInterface, Laminas\\\\Stdlib\\\\ResponseInterface given\\.$#"
 			count: 1
 			path: src/OAuth2Server/Controller/AuthorizeController.php
 
@@ -21,12 +21,12 @@ parameters:
 			path: src/OAuth2Server/Controller/AuthorizeController.php
 
 		-
-			message: "#^Parameter \\#2 \\$response of method OAuth2\\\\Server\\:\\:validateAuthorizeRequest\\(\\) expects OAuth2\\\\ResponseInterface\\|null, Zend\\\\Stdlib\\\\ResponseInterface given\\.$#"
+			message: "#^Parameter \\#2 \\$response of method OAuth2\\\\Server\\:\\:validateAuthorizeRequest\\(\\) expects OAuth2\\\\ResponseInterface\\|null, Laminas\\\\Stdlib\\\\ResponseInterface given\\.$#"
 			count: 1
 			path: src/OAuth2Server/Controller/AuthorizeController.php
 
 		-
-			message: "#^Call to an undefined method Zend\\\\Stdlib\\\\ResponseInterface\\:\\:getHeaders\\(\\)\\.$#"
+			message: "#^Call to an undefined method Laminas\\\\Stdlib\\\\ResponseInterface\\:\\:getHeaders\\(\\)\\.$#"
 			count: 1
 			path: src/OAuth2Server/Controller/AuthorizeController.php
 
@@ -36,12 +36,12 @@ parameters:
 			path: src/OAuth2Server/Controller/AuthorizeController.php
 
 		-
-			message: "#^Parameter \\#2 \\$response of method OAuth2\\\\Server\\:\\:handleTokenRequest\\(\\) expects OAuth2\\\\ResponseInterface\\|null, Zend\\\\Stdlib\\\\ResponseInterface given\\.$#"
+			message: "#^Parameter \\#2 \\$response of method OAuth2\\\\Server\\:\\:handleTokenRequest\\(\\) expects OAuth2\\\\ResponseInterface\\|null, Laminas\\\\Stdlib\\\\ResponseInterface given\\.$#"
 			count: 1
 			path: src/OAuth2Server/Controller/AuthorizeController.php
 
 		-
-			message: "#^Call to an undefined method Zend\\\\ServiceManager\\\\ServiceLocatorInterface\\:\\:getServiceLocator\\(\\)\\.$#"
+			message: "#^Call to an undefined method Laminas\\\\ServiceManager\\\\ServiceLocatorInterface\\:\\:getServiceLocator\\(\\)\\.$#"
 			count: 1
 			path: src/OAuth2Server/Controller/Factory/AuthorizeControllerFactory.php
 

--- a/src/OAuth2Server/Controller/AuthorizeController.php
+++ b/src/OAuth2Server/Controller/AuthorizeController.php
@@ -2,9 +2,9 @@
 
 namespace OAuth2Server\Controller;
 
-use Zend\Mvc\Controller\AbstractActionController;
-use Zend\View\Model\JsonModel;
-use OAuth2\ZendHttpPhpEnvironmentBridge\Request;
+use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\View\Model\JsonModel;
+use OAuth2\LaminasHttpPhpEnvironmentBridge\Request;
 use OAuth2\Server;
 
 class AuthorizeController extends AbstractActionController

--- a/src/OAuth2Server/Controller/Factory/AuthorizeControllerFactory.php
+++ b/src/OAuth2Server/Controller/Factory/AuthorizeControllerFactory.php
@@ -2,16 +2,16 @@
 
 namespace OAuth2Server\Controller\Factory;
 
-use Zend\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\FactoryInterface;
 use OAuth2Server\Controller\AuthorizeController;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 class AuthorizeControllerFactory implements FactoryInterface
 {
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        // This only gets called in older versions of Zend\ServiceManager,
+        // This only gets called in older versions of Laminas\ServiceManager,
         // left for backwards compatibility
         return $this($serviceLocator->getServiceLocator(), AuthorizeController::class);
     }

--- a/src/OAuth2Server/Form/AuthorizeForm.php
+++ b/src/OAuth2Server/Form/AuthorizeForm.php
@@ -1,8 +1,8 @@
 <?php
 namespace OAuth2Server\Form;
 
-use Zend\Form\Form;
-use Zend\Form\Element;
+use Laminas\Form\Form;
+use Laminas\Form\Element;
 
 class AuthorizeForm extends Form
 {


### PR DESCRIPTION
Migrates all Zend names to Laminas, depending on a dev dependency of another of our ZF2 libs that's migrating as well. Once all tested, will remove that and update version number.